### PR TITLE
allowing usage in IE11

### DIFF
--- a/vue-stickykit.js
+++ b/vue-stickykit.js
@@ -16,7 +16,7 @@ var index = {
    */
   install: function (Vue) {
     Vue.directive('stick-in-parent', {
-      bind(el, binding) {
+      bind: function(el, binding) {
         window.jQuery = window.jQuery || require('jquery');
         require('sticky-kit/dist/sticky-kit.js');
         jQuery(document).ready(function () {


### PR DESCRIPTION
This change remove the shorthand which when used in Internet Explorer throws a breaking error. 